### PR TITLE
fix: 修复API的域名变更导致的403问题

### DIFF
--- a/src-tauri/src/jm_client.rs
+++ b/src-tauri/src/jm_client.rs
@@ -27,7 +27,7 @@ const APP_TOKEN_SECRET_2: &str = "18comicAPPContent";
 const APP_DATA_SECRET: &str = "185Hcomic3PAPP7R";
 const APP_VERSION: &str = "1.7.3";
 
-const API_DOMAIN: &str = "www.jmeadpoolcdn.life";
+const API_DOMAIN: &str = "www.cdnxxx-proxy.org";
 
 #[derive(Debug, Clone, PartialEq)]
 enum ApiPath {


### PR DESCRIPTION
解决这个issue #22 