### PR TITLE
fix: 修复获取漫画信息被重定向到jm468984的问题

### DIFF
--- a/src-tauri/src/jm_client.rs
+++ b/src-tauri/src/jm_client.rs
@@ -30,7 +30,7 @@ const APP_TOKEN_SECRET_2: &str = "18comicAPPContent";
 const APP_DATA_SECRET: &str = "185Hcomic3PAPP7R";
 const APP_VERSION: &str = "1.7.5";
 
-const API_DOMAIN: &str = "www.cdnblackmyth.vip";
+const API_DOMAIN: &str = "www.jmapiproxyxxx.vip";
 
 #[derive(Debug, Clone, PartialEq)]
 enum ApiPath {


### PR DESCRIPTION
解决这个issue: #62 