### PR TITLE
fix: 修复漫画标题有换行符时导致的下载目录无法创建问题

### DIFF
--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -1,7 +1,7 @@
 pub fn filename_filter(s: &str) -> String {
     s.chars()
         .map(|c| match c {
-            '\\' | '/' => ' ',
+            '\\' | '/' | '\n' => ' ',
             ':' => '：',
             '*' => '⭐',
             '?' => '？',


### PR DESCRIPTION
解决这个issue #110 