### PR TITLE
fix: README with new Readme Card link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ https://github.com/user-attachments/assets/46096bd9-1fde-4474-b297-0f4389dbe770
 
 # 📚 哔咔漫画下载器  
 
-[![Readme Card](https://github-readme-stats.vercel.app/api/pin/?username=lanyeeee&repo=picacomic-downloader)](https://github.com/lanyeeee/picacomic-downloader)  
+[![Readme Card](https://github-readme-stats-lemon-chi-98.vercel.app/api/pin/?username=lanyeeee&repo=picacomic-downloader)](https://github.com/lanyeeee/picacomic-downloader)  
 
 # ⚠️ 关于被杀毒软件误判为病毒
 


### PR DESCRIPTION
https://github-readme-stats.vercel.app link error, this is my deploy

<img width="1083" height="159" alt="image" src="https://github.com/user-attachments/assets/5c10ae1b-7e2f-475f-bc49-319f6098afdd" />

<img width="529" height="205" alt="image" src="https://github.com/user-attachments/assets/b1be2d03-9945-4748-b2d8-056e35c1c8da" />


<!--
PR请提交至 develop 分支

如果想新加一个功能，请先开个 issue 或 discussion 讨论一下，避免无效工作

其他情况的PR欢迎直接提交，比如：
1.🔧 对原有功能的改进
2.🐛 修复BUG
3.⚡ 使用更轻量的库实现原有功能
4.📝 修订文档
5.⬆️ 升级、更新依赖的PR也会被接受
-->
